### PR TITLE
Symlink /proc/self/fd to /dev/fd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cbuildrt"
-version = "0.1.3"
+version = "0.1.4"
 description = "Containerized Build Runtime"
 license = "MIT"
 authors = ["The Managarm Project <info@managarm.org>"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,17 @@ fn concat_absolute<L: AsRef<Path>, R: AsRef<Path>>(lhs: L, rhs: R) -> PathBuf {
 }
 
 fn run_init(cfg: &Config) -> ! {
+    match std::os::unix::fs::symlink(
+        "/proc/self/fd",
+        &concat_absolute(&cfg.rootfs, "/dev/fd")
+    ) {
+        Ok(_) => {},
+        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {},
+        Err(err) => {
+            panic!("failed to symlink /dev/fd: {}", err)
+        }
+    }
+
     // We can now set up the remaining namespaces and perform mounts.
     let mut clone_flags = nix::sched::CloneFlags::CLONE_NEWNS;
     if cfg.isolate_network {


### PR DESCRIPTION
This link is needed for an example by java at build time.