### PR TITLE
Support deboostrap inside cbuildrt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 clap = "2.33"
 libc = "0.2"
 nix = "0.20"
-rustix = { version = "1.1.3", features = ["mount", "process"] }
+rustix = { version = "1.1.3", features = ["mount", "net", "process"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3.25.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,11 @@ edition = "2018"
 clap = "2.33"
 libc = "0.2"
 nix = "0.20"
-rustix = { version = "1.1.3", features = ["mount"] }
+rustix = { version = "1.1.3", features = ["mount", "process"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3.25.0"
+
+[dev-dependencies]
+assert_cmd = "2"
+predicates = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ nix = "0.20"
 rustix = { version = "1.1.3", features = ["mount", "net", "process"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+tar = "0.4"
 tempfile = "3.25.0"
 
 [dev-dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,6 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::ffi::CString;
 use std::fs::File;
-use std::mem::forget;
 use std::path::{Path, PathBuf};
 use std::process::exit;
 
@@ -34,7 +33,13 @@ struct Process {
 #[serde(untagged)]
 enum RootFs {
     Path(PathBuf),
-    Overlay { layers: Vec<PathBuf> },
+    Overlay {
+        layers: Vec<PathBuf>,
+        #[serde(default, rename = "withUpper")]
+        with_upper: bool,
+        #[serde(default, rename = "extractUpper")]
+        extract_upper: Option<PathBuf>,
+    },
 }
 
 #[derive(Serialize, Deserialize)]
@@ -68,11 +73,19 @@ struct Config {
     sub_gid: Option<SubIdRange>,
 }
 
+// Returns the config and the workspace directory (if one is passed).
 // TODO: This function does not really perform error checking;
 //       for now, we assume that xbstrap passes sane values.
-fn make_config_from_cli() -> Config {
+fn make_config_from_cli() -> (Config, Option<PathBuf>) {
     let matches = clap::App::new("cbuildrt")
         .version(crate_version!())
+        .arg(
+            clap::Arg::with_name("workspace")
+                .long("workspace")
+                .value_name("DIR")
+                .help("Directory to store cbuildrt's data (such as overlayfs layers)")
+                .takes_value(true),
+        )
         .arg(
             clap::Arg::with_name("cbuild-json")
                 .help("cbuild.json file")
@@ -80,10 +93,13 @@ fn make_config_from_cli() -> Config {
         )
         .get_matches();
 
+    let workspace = matches.value_of("workspace").map(PathBuf::from);
+
     let cfg_f =
         File::open(matches.value_of("cbuild-json").unwrap()).expect("unable to open cbuild.json");
 
-    serde_json::from_reader(cfg_f).expect("failed to parse cbuild.json")
+    let cfg = serde_json::from_reader(cfg_f).expect("failed to parse cbuild.json");
+    (cfg, workspace)
 }
 
 // Concatenates lhs and rhs as-if the rhs was a relative path.
@@ -91,7 +107,62 @@ fn concat_absolute<L: AsRef<Path>, R: AsRef<Path>>(lhs: L, rhs: R) -> PathBuf {
     lhs.as_ref().join(rhs.as_ref().strip_prefix("/").unwrap())
 }
 
-fn run_init(cfg: &Config, rootfs: Option<&Path>) -> ! {
+fn resolve_tar_layer(workspace: Option<&Path>, path: &Path) -> PathBuf {
+    let ext = path.extension().and_then(|e| e.to_str());
+    if ext != Some("tar") {
+        return path.to_path_buf();
+    }
+
+    let stem = path
+        .file_stem()
+        .expect("filename of tar lower layer has empty prefix");
+
+    let workspace =
+        workspace.expect("--workspace is required when an overlay uses tar lower layers");
+    let layers_root = workspace.join("layers");
+
+    // If the tar layer is already extracted, re-use the extracted version.
+    let extracted_dir = layers_root.join(stem);
+    if extracted_dir.exists() {
+        return extracted_dir;
+    }
+
+    // Extract into a staging directory.
+    std::fs::create_dir_all(&layers_root).expect("failed to create layer cache directory");
+    let staging = tempfile::Builder::new()
+        .prefix(".tmp-")
+        .tempdir_in(&layers_root)
+        .expect("failed to create staging dir for tar layer extraction");
+
+    let tar_file = File::open(path).expect("failed to open tar layer");
+    let mut archive = tar::Archive::new(tar_file);
+    archive.set_preserve_permissions(true);
+    archive.set_preserve_ownerships(true);
+    archive
+        .unpack(staging.path())
+        .expect("failed to extract tar layer");
+
+    // Rename to the final directory name.
+    let staging_path = staging.keep();
+    std::fs::rename(&staging_path, &extracted_dir)
+        .expect("failed to move extracted tar layer into cache");
+
+    extracted_dir
+}
+
+fn run_init(cfg: &Config, workspace: Option<&Path>, run_dir: Option<&Path>) -> ! {
+    // Derive the rootfs path.
+    let rootfs_owned: Option<PathBuf> = match &cfg.rootfs {
+        Some(RootFs::Path(path)) => Some(path.clone()),
+        Some(RootFs::Overlay { .. }) => {
+            let merged = run_dir.unwrap().join("merged");
+            std::fs::create_dir(&merged).expect("failed to create overlay merged dir");
+            Some(merged)
+        }
+        None => None,
+    };
+    let rootfs = rootfs_owned.as_deref();
+
     // We can now set up the remaining namespaces and perform mounts.
     let mut clone_flags = nix::sched::CloneFlags::CLONE_NEWNS;
     if cfg.isolate_network {
@@ -101,14 +172,35 @@ fn run_init(cfg: &Config, rootfs: Option<&Path>) -> ! {
 
     // Skip rootfs setup if we are running in namespace only mode.
     if let Some(rootfs) = rootfs {
-        if let Some(RootFs::Overlay { layers }) = &cfg.rootfs {
+        if let Some(RootFs::Overlay {
+            layers, with_upper, ..
+        }) = &cfg.rootfs
+        {
+            let resolved_layers: Vec<PathBuf> = layers
+                .iter()
+                .map(|p| resolve_tar_layer(workspace, p))
+                .collect();
+
             let mount =
                 rustix::mount::fsopen("overlay", rustix::mount::FsOpenFlags::FSOPEN_CLOEXEC)
                     .expect("failed to open overlay filesystem");
-
-            for path in layers {
+            for path in &resolved_layers {
                 rustix::mount::fsconfig_set_string(&mount, "lowerdir+", path)
                     .expect("failed to set overlay lowerdir option");
+            }
+            if *with_upper {
+                let run_dir =
+                    run_dir.expect("withUpper is set but no overlay tempdir was provided");
+                let upper = run_dir.join("upper");
+                let work = run_dir.join("work");
+                std::fs::create_dir(&upper).expect("failed to create overlay upper dir");
+                std::fs::create_dir(&work).expect("failed to create overlay work dir");
+                rustix::mount::fsconfig_set_string(&mount, "upperdir", &upper)
+                    .expect("failed to set overlay upperdir option");
+                rustix::mount::fsconfig_set_string(&mount, "workdir", &work)
+                    .expect("failed to set overlay workdir option");
+                rustix::mount::fsconfig_set_flag(&mount, "userxattr")
+                    .expect("failed to set overlay userxattr option");
             }
 
             rustix::mount::fsconfig_create(&mount).expect("failed to create overlay filesystem");
@@ -271,12 +363,6 @@ fn run_init(cfg: &Config, rootfs: Option<&Path>) -> ! {
         .expect("failed to perform bind mount");
     }
 
-    if let Some(rootfs) = rootfs {
-        // chroot() and change the current directory to /.
-        nix::unistd::chroot(rootfs).expect("failed to chroot()");
-        nix::unistd::chdir("/").expect("failed to chdir() to root directory");
-    }
-
     // TODO: We could drop privileges here.
     //       (However, cbuildrt does not really protect against malicious sandbox escapes.)
 
@@ -285,6 +371,18 @@ fn run_init(cfg: &Config, rootfs: Option<&Path>) -> ! {
     // (We cannot use Rust's high-level API since we need to reap orphans.)
     match unsafe { nix::unistd::fork() } {
         Ok(nix::unistd::ForkResult::Child) => {
+            if let Some(rootfs) = rootfs {
+                nix::unistd::chroot(rootfs).expect("failed to chroot()");
+                nix::unistd::chdir("/").expect("failed to chdir() to root directory");
+            }
+
+            // setuid/setgid in the child only such that the init process can do cleanup as root.
+            // setgid before setuid since setuid drops capabilities.
+            nix::unistd::setgid(nix::unistd::Gid::from_raw(cfg.user.gid))
+                .expect("failed to set GID");
+            nix::unistd::setuid(nix::unistd::Uid::from_raw(cfg.user.uid))
+                .expect("failed to set UID");
+
             // Reset PATH to the default value
             if cfg.user.uid == 0 {
                 std::env::set_var(
@@ -312,18 +410,43 @@ fn run_init(cfg: &Config, rootfs: Option<&Path>) -> ! {
             exit(1);
         }
         Ok(nix::unistd::ForkResult::Parent { child: child_pid }) => {
+            let child_exit_code;
             loop {
                 // Now, let's wait for the child to terminate.
                 let child_status = nix::sys::wait::wait().expect("failed to wait for children");
                 if let nix::sys::wait::WaitStatus::Exited(pid, code) = child_status {
                     if pid == child_pid {
-                        if code != 0 {
-                            eprintln!("child returned non-zero exit code");
-                        }
-                        exit(code);
+                        child_exit_code = code;
+                        break;
                     }
                 }
             }
+
+            // If the command succeeded, extract the upper layer as a tar.
+            if child_exit_code == 0 {
+                if let Some(RootFs::Overlay {
+                    with_upper: true,
+                    extract_upper: Some(dest),
+                    ..
+                }) = &cfg.rootfs
+                {
+                    let upper = run_dir
+                        .expect("extractUpper is set but no overlay tempdir was provided")
+                        .join("upper");
+                    let tar_file = File::create(dest).expect("failed to create output tar file");
+                    let mut builder = tar::Builder::new(tar_file);
+                    builder.follow_symlinks(false);
+                    builder
+                        .append_dir_all(".", upper)
+                        .expect("failed to write upper layer to tar");
+                    builder.finish().expect("failed to finalize tar archive");
+                }
+            }
+
+            if child_exit_code != 0 {
+                eprintln!("child returned non-zero exit code");
+            }
+            exit(child_exit_code);
         }
         Err(_) => panic!("failed to fork from init"),
     };
@@ -481,32 +604,24 @@ fn run_userns_helper(
 }
 
 fn main() {
-    let cfg = make_config_from_cli();
+    let (cfg, workspace) = make_config_from_cli();
 
-    let merged_overlay =
-        tempfile::tempdir().expect("failed to create temporary directory for merged overlay");
+    if let Some(RootFs::Path(path)) = &cfg.rootfs {
+        let lockfile_path = path
+            .parent()
+            .and_then(|p| Some(p.join(path.file_name()?)))
+            .map(|p| p.with_extension("cbrt_lock"))
+            .expect("couldn't construct lockfile path");
 
-    let rootfs = match &cfg.rootfs {
-        Some(RootFs::Path(path)) => {
-            let lockfile_path = path
-                .parent()
-                .and_then(|p| Some(p.join(path.file_name()?)))
-                .map(|p| p.with_extension("cbrt_lock"))
-                .expect("couldn't construct lockfile path");
+        let root_dir = open(
+            &lockfile_path,
+            OFlag::O_RDONLY | OFlag::O_CREAT | OFlag::O_CLOEXEC,
+            Mode::from_bits(0o444).unwrap(),
+        )
+        .expect("couldn't open rootfs for locking");
 
-            let root_dir = open(
-                &lockfile_path,
-                OFlag::O_RDONLY | OFlag::O_CREAT | OFlag::O_CLOEXEC,
-                Mode::from_bits(0o444).unwrap(),
-            )
-            .expect("couldn't open rootfs for locking");
-
-            flock(root_dir, FlockArg::LockShared).expect("failed to lock rootdir");
-            Some(path.to_path_buf())
-        }
-        Some(RootFs::Overlay { .. }) => Some(merged_overlay.path().to_path_buf()),
-        None => None,
-    };
+        flock(root_dir, FlockArg::LockShared).expect("failed to lock rootdir");
+    }
 
     let euid = nix::unistd::geteuid();
     let egid = nix::unistd::getegid();
@@ -530,7 +645,6 @@ fn main() {
             match unsafe { nix::unistd::fork() } {
                 Ok(nix::unistd::ForkResult::Child) => {
                     drop(sock_main);
-                    forget(merged_overlay);
                     run_userns_helper(
                         euid,
                         egid,
@@ -571,16 +685,31 @@ fn main() {
         setup_userns_direct(&cfg, euid, egid);
     }
 
-    // Change user IDs.
-    nix::unistd::setuid(nix::unistd::Uid::from_raw(cfg.user.uid)).expect("failed to set UID");
-    nix::unistd::setgid(nix::unistd::Gid::from_raw(cfg.user.gid)).expect("failed to set GID");
+    // Some configurations need a per-run directory to store temporary data.
+    // Note that cleanup of the per-run directory requires us to be in the user namespace
+    // (but this process is in the user namespace anyway).
+    let need_tempdir = matches!(cfg.rootfs, Some(RootFs::Overlay { .. }));
+    let run_tempdir: Option<tempfile::TempDir> = if need_tempdir {
+        let run_root = workspace
+            .as_deref()
+            .expect("--workspace is required for overlay rootfs")
+            .join("run");
+        std::fs::create_dir_all(&run_root)
+            .expect("failed to create cbuildrt overlay cache directory");
+        let dir = tempfile::Builder::new()
+            .tempdir_in(&run_root)
+            .expect("failed to create per-run overlay tempdir");
+        Some(dir)
+    } else {
+        None
+    };
+    let run_dir = run_tempdir.as_ref().map(|d| d.path());
 
     // fork() and run init in the child.
     // The parent waits for the child to terminate.
     match unsafe { nix::unistd::fork() } {
         Ok(nix::unistd::ForkResult::Child) => {
-            forget(merged_overlay);
-            run_init(&cfg, rootfs.as_deref());
+            run_init(&cfg, workspace.as_deref(), run_dir);
         }
         Ok(nix::unistd::ForkResult::Parent { child: init_pid }) => {
             eprintln!("PID init is {} (outside the namespace)", init_pid);
@@ -593,7 +722,6 @@ fn main() {
                 _ => panic!("waiting for init returned {:?}", init_status),
             };
 
-            drop(merged_overlay);
             exit(init_code);
         }
         Err(_) => panic!("failed to fork from cbuildrt"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,10 @@ enum RootFs {
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct Config {
-    rootfs: RootFs,
+    // If no rootfs is passed, we are running in namespace only mode.
+    // That is, we will still enter namespace but not chroot().
+    #[serde(default)]
+    rootfs: Option<RootFs>,
     user: User,
     process: Process,
     #[serde(default)]
@@ -67,7 +70,7 @@ fn concat_absolute<L: AsRef<Path>, R: AsRef<Path>>(lhs: L, rhs: R) -> PathBuf {
     lhs.as_ref().join(rhs.as_ref().strip_prefix("/").unwrap())
 }
 
-fn run_init(cfg: &Config, rootfs: &Path) -> ! {
+fn run_init(cfg: &Config, rootfs: Option<&Path>) -> ! {
     // We can now set up the remaining namespaces and perform mounts.
     let mut clone_flags = nix::sched::CloneFlags::CLONE_NEWNS;
     if cfg.isolate_network {
@@ -75,136 +78,140 @@ fn run_init(cfg: &Config, rootfs: &Path) -> ! {
     }
     nix::sched::unshare(clone_flags).expect("failed to unshare()");
 
-    if let RootFs::Overlay { layers } = &cfg.rootfs {
-        let mount = rustix::mount::fsopen("overlay", rustix::mount::FsOpenFlags::FSOPEN_CLOEXEC)
-            .expect("failed to open overlay filesystem");
+    // Skip rootfs setup if we are running in namespace only mode.
+    if let Some(rootfs) = rootfs {
+        if let Some(RootFs::Overlay { layers }) = &cfg.rootfs {
+            let mount =
+                rustix::mount::fsopen("overlay", rustix::mount::FsOpenFlags::FSOPEN_CLOEXEC)
+                    .expect("failed to open overlay filesystem");
 
-        for path in layers {
-            rustix::mount::fsconfig_set_string(&mount, "lowerdir+", path)
-                .expect("failed to set overlay lowerdir option");
+            for path in layers {
+                rustix::mount::fsconfig_set_string(&mount, "lowerdir+", path)
+                    .expect("failed to set overlay lowerdir option");
+            }
+
+            rustix::mount::fsconfig_create(&mount).expect("failed to create overlay filesystem");
+
+            let mount = rustix::mount::fsmount(
+                &mount,
+                rustix::mount::FsMountFlags::FSMOUNT_CLOEXEC,
+                rustix::mount::MountAttrFlags::empty(),
+            )
+            .expect("failed to mount overlay filesystem");
+
+            rustix::mount::move_mount(
+                &mount,
+                "",
+                rustix::fs::CWD,
+                rootfs,
+                rustix::mount::MoveMountFlags::MOVE_MOUNT_F_EMPTY_PATH,
+            )
+            .expect("failed to move overlay filesystem to rootfs");
+        } else {
+            // First, we need to get a read-only rootfs.
+            // Mounting with MS_BIND ignored MS_RDONLY, but MS_REMOUNT respects it.
+            nix::mount::mount(
+                Some(rootfs),
+                rootfs,
+                None::<&str>,
+                nix::mount::MsFlags::MS_BIND,
+                None::<&str>,
+            )
+            .expect("failed to bind mount rootfs to itself");
+
+            // The fs might be mounted as nosuid/nodev and we will not have permissions
+            // to strip these mount options.
+            // Instead of parsing the current mount table, just set these flags unconditionally for now.
+            nix::mount::mount(
+                Some(rootfs),
+                rootfs,
+                None::<&str>,
+                nix::mount::MsFlags::MS_REMOUNT
+                    | nix::mount::MsFlags::MS_BIND
+                    | nix::mount::MsFlags::MS_RDONLY
+                    | nix::mount::MsFlags::MS_NOSUID
+                    | nix::mount::MsFlags::MS_NODEV,
+                None::<&str>,
+            )
+            .expect("failed to make rootfs read-only");
         }
 
-        rustix::mount::fsconfig_create(&mount).expect("failed to create overlay filesystem");
+        // Perform mounts of /dev, /dev/pts, /dev/shm, /run, /tmp and /proc.
 
-        let mount = rustix::mount::fsmount(
-            &mount,
-            rustix::mount::FsMountFlags::FSMOUNT_CLOEXEC,
-            rustix::mount::MountAttrFlags::empty(),
-        )
-        .expect("failed to mount overlay filesystem");
+        let dev_overlays = vec!["tty", "null", "zero", "full", "random", "urandom"];
+        for f in dev_overlays {
+            nix::mount::mount(
+                Some(&Path::new("/dev/").join(f)),
+                &concat_absolute(rootfs, "/dev/").join(f),
+                None::<&str>,
+                nix::mount::MsFlags::MS_BIND,
+                None::<&str>,
+            )
+            .expect("failed to mount device");
+        }
 
-        rustix::mount::move_mount(
-            &mount,
-            "",
-            rustix::fs::CWD,
-            rootfs,
-            rustix::mount::MoveMountFlags::MOVE_MOUNT_F_EMPTY_PATH,
-        )
-        .expect("failed to move overlay filesystem to rootfs");
-    } else {
-        // First, we need to get a read-only rootfs.
-        // Mounting with MS_BIND ignored MS_RDONLY, but MS_REMOUNT respects it.
+        if !cfg.isolate_network {
+            nix::mount::mount(
+                Some(&std::fs::canonicalize("/etc/resolv.conf").unwrap()),
+                &concat_absolute(rootfs, "/etc/resolv.conf"),
+                None::<&str>,
+                nix::mount::MsFlags::MS_BIND,
+                None::<&str>,
+            )
+            .expect("failed to mount /etc/resolv.conf");
+        }
+
         nix::mount::mount(
-            Some(rootfs),
-            rootfs,
             None::<&str>,
-            nix::mount::MsFlags::MS_BIND,
+            &concat_absolute(rootfs, "/dev/pts"),
+            Some("devpts"),
+            nix::mount::MsFlags::empty(),
             None::<&str>,
         )
-        .expect("failed to bind mount rootfs to itself");
+        .expect("failed to mount /dev/pts");
 
-        // The fs might be mounted as nosuid/nodev and we will not have permissions
-        // to strip these mount options.
-        // Instead of parsing the current mount table, just set these flags unconditionally for now.
         nix::mount::mount(
-            Some(rootfs),
-            rootfs,
             None::<&str>,
-            nix::mount::MsFlags::MS_REMOUNT
-                | nix::mount::MsFlags::MS_BIND
-                | nix::mount::MsFlags::MS_RDONLY
-                | nix::mount::MsFlags::MS_NOSUID
-                | nix::mount::MsFlags::MS_NODEV,
+            &concat_absolute(rootfs, "/dev/shm"),
+            Some("tmpfs"),
+            nix::mount::MsFlags::empty(),
             None::<&str>,
         )
-        .expect("failed to make rootfs read-only");
+        .expect("failed to mount /dev/shm");
+
+        nix::mount::mount(
+            None::<&str>,
+            &concat_absolute(rootfs, "/run"),
+            Some("tmpfs"),
+            nix::mount::MsFlags::empty(),
+            None::<&str>,
+        )
+        .expect("failed to mount /run");
+
+        nix::mount::mount(
+            None::<&str>,
+            &concat_absolute(rootfs, "/tmp"),
+            Some("tmpfs"),
+            nix::mount::MsFlags::empty(),
+            None::<&str>,
+        )
+        .expect("failed to mount /tmp");
+
+        nix::mount::mount(
+            None::<&str>,
+            &concat_absolute(rootfs, "/proc"),
+            Some("proc"),
+            nix::mount::MsFlags::empty(),
+            None::<&str>,
+        )
+        .expect("failed to mount /proc");
     }
-
-    // Perform mounts of /dev, /dev/pts, /dev/shm, /run, /tmp and /proc.
-
-    let dev_overlays = vec!["tty", "null", "zero", "full", "random", "urandom"];
-    for f in dev_overlays {
-        nix::mount::mount(
-            Some(&Path::new("/dev/").join(f)),
-            &concat_absolute(rootfs, "/dev/").join(f),
-            None::<&str>,
-            nix::mount::MsFlags::MS_BIND,
-            None::<&str>,
-        )
-        .expect("failed to mount device");
-    }
-
-    if !cfg.isolate_network {
-        nix::mount::mount(
-            Some(&std::fs::canonicalize("/etc/resolv.conf").unwrap()),
-            &concat_absolute(rootfs, "/etc/resolv.conf"),
-            None::<&str>,
-            nix::mount::MsFlags::MS_BIND,
-            None::<&str>,
-        )
-        .expect("failed to mount /etc/resolv.conf");
-    }
-
-    nix::mount::mount(
-        None::<&str>,
-        &concat_absolute(rootfs, "/dev/pts"),
-        Some("devpts"),
-        nix::mount::MsFlags::empty(),
-        None::<&str>,
-    )
-    .expect("failed to mount /dev/pts");
-
-    nix::mount::mount(
-        None::<&str>,
-        &concat_absolute(rootfs, "/dev/shm"),
-        Some("tmpfs"),
-        nix::mount::MsFlags::empty(),
-        None::<&str>,
-    )
-    .expect("failed to mount /dev/shm");
-
-    nix::mount::mount(
-        None::<&str>,
-        &concat_absolute(rootfs, "/run"),
-        Some("tmpfs"),
-        nix::mount::MsFlags::empty(),
-        None::<&str>,
-    )
-    .expect("failed to mount /run");
-
-    nix::mount::mount(
-        None::<&str>,
-        &concat_absolute(rootfs, "/tmp"),
-        Some("tmpfs"),
-        nix::mount::MsFlags::empty(),
-        None::<&str>,
-    )
-    .expect("failed to mount /tmp");
-
-    nix::mount::mount(
-        None::<&str>,
-        &concat_absolute(rootfs, "/proc"),
-        Some("proc"),
-        nix::mount::MsFlags::empty(),
-        None::<&str>,
-    )
-    .expect("failed to mount /proc");
 
     // Perform bind mounts requested by user.
     for bm in &cfg.bind_mounts {
         nix::mount::mount(
             Some(&bm.source),
-            &concat_absolute(rootfs, &bm.destination),
+            &concat_absolute(rootfs.unwrap_or(Path::new("/")), &bm.destination),
             None::<&str>,
             nix::mount::MsFlags::MS_BIND | nix::mount::MsFlags::MS_REC,
             None::<&str>,
@@ -212,9 +219,11 @@ fn run_init(cfg: &Config, rootfs: &Path) -> ! {
         .expect("failed to perform bind mount");
     }
 
-    // chroot() and change the current directory to /.
-    nix::unistd::chroot(rootfs).expect("failed to chroot()");
-    nix::unistd::chdir("/").expect("failed to chdir() to root directory");
+    if let Some(rootfs) = rootfs {
+        // chroot() and change the current directory to /.
+        nix::unistd::chroot(rootfs).expect("failed to chroot()");
+        nix::unistd::chdir("/").expect("failed to chdir() to root directory");
+    }
 
     // TODO: We could drop privileges here.
     //       (However, cbuildrt does not really protect against malicious sandbox escapes.)
@@ -270,7 +279,7 @@ fn main() {
         tempfile::tempdir().expect("failed to create temporary directory for merged overlay");
 
     let rootfs = match &cfg.rootfs {
-        RootFs::Path(path) => {
+        Some(RootFs::Path(path)) => {
             let lockfile_path = path
                 .parent()
                 .and_then(|p| Some(p.join(path.file_name()?)))
@@ -285,9 +294,10 @@ fn main() {
             .expect("couldn't open rootfs for locking");
 
             flock(root_dir, FlockArg::LockShared).expect("failed to lock rootdir");
-            path.to_path_buf()
+            Some(path.to_path_buf())
         }
-        RootFs::Overlay { .. } => merged_overlay.path().to_path_buf(),
+        Some(RootFs::Overlay { .. }) => Some(merged_overlay.path().to_path_buf()),
+        None => None,
     };
 
     let euid = nix::unistd::geteuid();
@@ -320,7 +330,7 @@ fn main() {
     match unsafe { nix::unistd::fork() } {
         Ok(nix::unistd::ForkResult::Child) => {
             forget(merged_overlay);
-            run_init(&cfg, &rootfs);
+            run_init(&cfg, rootfs.as_deref());
         }
         Ok(nix::unistd::ForkResult::Parent { child: init_pid }) => {
             eprintln!("PID init is {} (outside the namespace)", init_pid);

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,7 +157,7 @@ fn run_init(cfg: &Config, rootfs: Option<&Path>) -> ! {
             .expect("failed to make rootfs read-only");
         }
 
-        // Perform mounts of /dev, /dev/pts, /dev/shm, /run, /tmp and /proc.
+        // Perform mounts of /dev, /dev/pts, /dev/shm, /run, /tmp, /var/tmp, /sys, and /proc.
 
         let dev_overlays = vec!["tty", "null", "zero", "full", "random", "urandom"];
         for f in dev_overlays {
@@ -226,6 +226,37 @@ fn run_init(cfg: &Config, rootfs: Option<&Path>) -> ! {
             None::<&str>,
         )
         .expect("failed to mount /proc");
+
+        // Mount /var/tmp as tmpfs.
+        // TODO: Technically /var/tmp is supposed to survive boots.
+        nix::mount::mount(
+            None::<&str>,
+            &concat_absolute(rootfs, "/var/tmp"),
+            Some("tmpfs"),
+            nix::mount::MsFlags::empty(),
+            None::<&str>,
+        )
+        .expect("failed to mount /var/tmp");
+
+        // Mount /sys via recursive bind + slave.
+        // This is needed such that the container can access /sys/fs/* and similar.
+        nix::mount::mount(
+            Some(Path::new("/sys")),
+            &concat_absolute(rootfs, "/sys"),
+            None::<&str>,
+            nix::mount::MsFlags::MS_BIND | nix::mount::MsFlags::MS_REC,
+            None::<&str>,
+        )
+        .expect("failed to bind mount /sys");
+
+        nix::mount::mount(
+            None::<&str>,
+            &concat_absolute(rootfs, "/sys"),
+            None::<&str>,
+            nix::mount::MsFlags::MS_SLAVE | nix::mount::MsFlags::MS_REC,
+            None::<&str>,
+        )
+        .expect("failed to make /sys slave");
     }
 
     // Perform bind mounts requested by user.

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,12 @@ struct BindMount {
 }
 
 #[derive(Serialize, Deserialize)]
+struct Volume {
+    name: String,
+    destination: PathBuf,
+}
+
+#[derive(Serialize, Deserialize)]
 struct User {
     uid: uid_t,
     gid: gid_t,
@@ -67,6 +73,8 @@ struct Config {
     #[serde(default)]
     isolate_network: bool,
     bind_mounts: Vec<BindMount>,
+    #[serde(default)]
+    volumes: Vec<Volume>,
     #[serde(default)]
     sub_uid: Option<SubIdRange>,
     #[serde(default)]
@@ -369,6 +377,25 @@ fn run_init(cfg: &Config, workspace: Option<&Path>, run_dir: Option<&Path>) -> !
             None::<&str>,
         )
         .expect("failed to perform bind mount");
+    }
+
+    // Perform volume mounts.
+    for vol in &cfg.volumes {
+        let source = workspace
+            .expect("--workspace is required for volumes")
+            .join("volumes")
+            .join(&vol.name);
+        std::fs::create_dir_all(&source).expect("failed to create volume directory");
+        let dest = concat_absolute(rootfs.unwrap_or(Path::new("/")), &vol.destination);
+        std::fs::create_dir_all(&dest).expect("failed to create volume mount point");
+        nix::mount::mount(
+            Some(&source),
+            &dest,
+            None::<&str>,
+            nix::mount::MsFlags::MS_BIND | nix::mount::MsFlags::MS_REC,
+            None::<&str>,
+        )
+        .expect("failed to perform volume mount");
     }
 
     // TODO: We could drop privileges here.

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use clap::crate_version;
 use libc::{gid_t, uid_t};
 use nix::fcntl::{flock, open, FlockArg, OFlag};
 use nix::sys::stat::Mode;
+use rustix::fd::AsFd;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::ffi::CString;
@@ -37,7 +38,20 @@ enum RootFs {
 }
 
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+struct SubIdRange {
+    #[serde(default)]
+    auto: bool,
+    #[serde(default)]
+    start: u64,
+    #[serde(default)]
+    count: u64,
+    #[serde(rename = "self")]
+    self_id: u64,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 struct Config {
     // If no rootfs is passed, we are running in namespace only mode.
     // That is, we will still enter namespace but not chroot().
@@ -48,6 +62,10 @@ struct Config {
     #[serde(default)]
     isolate_network: bool,
     bind_mounts: Vec<BindMount>,
+    #[serde(default)]
+    sub_uid: Option<SubIdRange>,
+    #[serde(default)]
+    sub_gid: Option<SubIdRange>,
 }
 
 // TODO: This function does not really perform error checking;
@@ -280,6 +298,157 @@ fn run_init(cfg: &Config, rootfs: Option<&Path>) -> ! {
     };
 }
 
+fn setup_userns_direct(cfg: &Config, euid: nix::unistd::Uid, egid: nix::unistd::Gid) {
+    // Write the uid_map and gid_map files. Linux demands that we write setgroups first
+    // (otherwise, we need to be root in the outer namespace).
+    std::fs::write("/proc/self/setgroups", "deny").expect("unable to write setgroups file");
+
+    std::fs::write("/proc/self/uid_map", format!("{} {} 1", cfg.user.uid, euid))
+        .expect("unable to write uid_map file");
+    std::fs::write("/proc/self/gid_map", format!("{} {} 1", cfg.user.gid, egid))
+        .expect("unable to write gid_map file");
+}
+
+fn setup_userns_with_helper(sock: rustix::fd::BorrowedFd) {
+    // Signal the helper that we have unshare()d.
+    rustix::net::send(sock, &[1u8], rustix::net::SendFlags::empty())
+        .expect("failed to signal helper");
+
+    // Wait for helper to finish setting up mappings.
+    let mut done = [0u8; 1];
+    let (_, n) = rustix::net::recv(sock, &mut done, rustix::net::RecvFlags::empty())
+        .expect("failed to read from helper");
+    if n == 0 {
+        panic!("helper closed socket without signaling completion");
+    }
+}
+
+fn parse_subordinate_file(path: &str, username: &str) -> (u64, u64) {
+    let content =
+        std::fs::read_to_string(path).unwrap_or_else(|e| panic!("failed to read {}: {}", path, e));
+    for line in content.lines() {
+        let parts: Vec<&str> = line.splitn(3, ':').collect();
+        if parts.len() == 3 && parts[0] == username {
+            let start: u64 = parts[1]
+                .parse()
+                .expect("invalid start in subordinate ID file");
+            let count: u64 = parts[2]
+                .parse()
+                .expect("invalid count in subordinate ID file");
+            return (start, count);
+        }
+    }
+    panic!("no entry for user '{}' in {}", username, path);
+}
+
+fn resolve_id_range(range: &SubIdRange, file: &str) -> (u64, u64) {
+    if range.auto {
+        let euid = nix::unistd::geteuid();
+        let user = nix::unistd::User::from_uid(euid)
+            .expect("failed to look up user")
+            .unwrap_or_else(|| panic!("no passwd entry for uid {}", euid));
+        parse_subordinate_file(file, &user.name)
+    } else {
+        (range.start, range.count)
+    }
+}
+
+// Build setuidmap/setgidmap args to map [0, sub_count) inside userns
+// to [sub_start, sub_start + sub_count) outside userns,
+// except for self_id which is mapped to host_self_id.
+fn build_id_mapping_args(
+    self_id: u64,
+    host_self_id: u64,
+    sub_start: u64,
+    sub_count: u64,
+) -> Vec<(u64, u64, u64)> {
+    let mut mappings = vec![(self_id, host_self_id, 1)];
+    // Map part of [0, sub_count) that is below self_id.
+    if self_id > 0 {
+        if self_id < sub_count {
+            mappings.push((0, sub_start, self_id));
+        } else {
+            mappings.push((0, sub_start, sub_count));
+        }
+    }
+    // Map part of [0, sub_count) that is at or above (self_id + 1).
+    if self_id + 1 < sub_count {
+        mappings.push((
+            self_id + 1,
+            sub_start + self_id + 1,
+            sub_count - (self_id + 1),
+        ));
+    }
+
+    mappings
+}
+
+fn run_userns_helper(
+    euid: nix::unistd::Uid,
+    egid: nix::unistd::Gid,
+    subuid: (u64, u64),
+    subgid: (u64, u64),
+    self_uid: u64,
+    self_gid: u64,
+    main_pid: nix::unistd::Pid,
+    sock: rustix::fd::OwnedFd,
+) -> ! {
+    // Wait for the main process to signal that it has unshared.
+    let mut ready = [0u8; 1];
+    let (_, n) = rustix::net::recv(&sock, &mut ready, rustix::net::RecvFlags::empty())
+        .expect("failed to read from main process");
+    if n == 0 {
+        exit(1);
+    }
+
+    let uid_mappings = build_id_mapping_args(self_uid, euid.as_raw().into(), subuid.0, subuid.1);
+    let mut cmd = std::process::Command::new("newuidmap");
+    cmd.arg(main_pid.as_raw().to_string());
+    for (inner, outer, count) in &uid_mappings {
+        cmd.args([inner.to_string(), outer.to_string(), count.to_string()]);
+    }
+    let status = cmd.status();
+    match status {
+        Ok(s) if s.success() => {}
+        Ok(s) => {
+            if !s.success() {
+                eprintln!("newuidmap failed with exit code {:?}", s.code());
+                exit(1);
+            }
+        }
+        Err(e) => {
+            eprintln!("failed to run newuidmap: {}", e);
+            exit(1);
+        }
+    }
+
+    let gid_mappings = build_id_mapping_args(self_gid, egid.as_raw().into(), subgid.0, subgid.1);
+    let mut cmd = std::process::Command::new("newgidmap");
+    cmd.arg(main_pid.as_raw().to_string());
+    for (inner, outer, count) in &gid_mappings {
+        cmd.args([inner.to_string(), outer.to_string(), count.to_string()]);
+    }
+    let status = cmd.status();
+    match status {
+        Ok(s) => {
+            if !s.success() {
+                eprintln!("newgidmap failed with exit code {:?}", s.code());
+                exit(1);
+            }
+        }
+        Err(e) => {
+            eprintln!("failed to run newgidmap: {}", e);
+            exit(1);
+        }
+    }
+
+    // Signal the main process that mappings are done.
+    rustix::net::send(&sock, &[1u8], rustix::net::SendFlags::empty())
+        .expect("failed to signal main process");
+
+    exit(0);
+}
+
 fn main() {
     let cfg = make_config_from_cli();
 
@@ -311,6 +480,47 @@ fn main() {
     let euid = nix::unistd::geteuid();
     let egid = nix::unistd::getegid();
 
+    // Launch a helper process to run set{uid,gid}map.
+    let (helper_pid, sock_main) =
+        if let (Some(sub_uid), Some(sub_gid)) = (&cfg.sub_uid, &cfg.sub_gid) {
+            let resolved_subuid = resolve_id_range(sub_uid, "/etc/subuid");
+            let resolved_subgid = resolve_id_range(sub_gid, "/etc/subgid");
+
+            // Set up socketpair for helper synchronization if using subordinate IDs.
+            let (sock_main, sock_helper) = rustix::net::socketpair(
+                rustix::net::AddressFamily::UNIX,
+                rustix::net::SocketType::SEQPACKET,
+                rustix::net::SocketFlags::CLOEXEC,
+                None,
+            )
+            .expect("failed to create socketpair for helper sync");
+
+            let main_pid = nix::unistd::getpid();
+            match unsafe { nix::unistd::fork() } {
+                Ok(nix::unistd::ForkResult::Child) => {
+                    drop(sock_main);
+                    forget(merged_overlay);
+                    run_userns_helper(
+                        euid,
+                        egid,
+                        resolved_subuid,
+                        resolved_subgid,
+                        sub_uid.self_id,
+                        sub_gid.self_id,
+                        main_pid,
+                        sock_helper,
+                    );
+                }
+                Ok(nix::unistd::ForkResult::Parent { child }) => {
+                    drop(sock_helper);
+                    (Some(child), Some(sock_main))
+                }
+                Err(_) => panic!("failed to fork helper for ID mapping"),
+            }
+        } else {
+            (None, None)
+        };
+
     // Enter the user namespace and let children enter a new PID namespace.
     // We cannot do mounts in this process yet, as this the process itself
     // is not moved to the new PID namespace.
@@ -319,15 +529,16 @@ fn main() {
     )
     .expect("failed to unshare()");
 
-    // Write the uid_map and gid_map files. Linux demands that we write setgroups first
-    // (otherwise, we need to be root in the outer namespace).
-
-    std::fs::write("/proc/self/setgroups", "deny").expect("unable to write setgroups file");
-
-    std::fs::write("/proc/self/uid_map", format!("{} {} 1", cfg.user.uid, euid))
-        .expect("unable to write uid_map file");
-    std::fs::write("/proc/self/gid_map", format!("{} {} 1", cfg.user.gid, egid))
-        .expect("unable to write gid_map file");
+    if cfg.sub_uid.is_some() && cfg.sub_gid.is_some() {
+        setup_userns_with_helper(sock_main.unwrap().as_fd());
+        nix::sys::wait::waitpid(
+            helper_pid.expect("set{uid,gid}map helper PID must be known"),
+            None,
+        )
+        .expect("failed to wait for helper");
+    } else {
+        setup_userns_direct(&cfg, euid, egid);
+    }
 
     // Change user IDs.
     nix::unistd::setuid(nix::unistd::Uid::from_raw(cfg.user.uid)).expect("failed to set UID");

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,13 @@ struct Config {
     sub_uid: Option<SubIdRange>,
     #[serde(default)]
     sub_gid: Option<SubIdRange>,
+    // Do not chroot() into the rootfs. Note that we still chdir() into it.
+    // This is useful to build container base images by using host tools (e.g., debootstrap).
+    #[serde(default)]
+    no_chroot: bool,
+    // Do not perform system mounts such as /proc, /tmp, /sys etc.
+    #[serde(default)]
+    no_system_mounts: bool,
 }
 
 // Returns the config and the workspace directory (if one is passed).
@@ -250,105 +257,106 @@ fn run_init(cfg: &Config, workspace: Option<&Path>, run_dir: Option<&Path>) -> !
         }
 
         // Perform mounts of /dev, /dev/pts, /dev/shm, /run, /tmp, /var/tmp, /sys, and /proc.
+        if !cfg.no_system_mounts {
+            let dev_overlays = vec!["tty", "null", "zero", "full", "random", "urandom"];
+            for f in dev_overlays {
+                nix::mount::mount(
+                    Some(&Path::new("/dev/").join(f)),
+                    &concat_absolute(rootfs, "/dev/").join(f),
+                    None::<&str>,
+                    nix::mount::MsFlags::MS_BIND,
+                    None::<&str>,
+                )
+                .expect("failed to mount device");
+            }
 
-        let dev_overlays = vec!["tty", "null", "zero", "full", "random", "urandom"];
-        for f in dev_overlays {
+            if !cfg.isolate_network {
+                nix::mount::mount(
+                    Some(&std::fs::canonicalize("/etc/resolv.conf").unwrap()),
+                    &concat_absolute(rootfs, "/etc/resolv.conf"),
+                    None::<&str>,
+                    nix::mount::MsFlags::MS_BIND,
+                    None::<&str>,
+                )
+                .expect("failed to mount /etc/resolv.conf");
+            }
+
             nix::mount::mount(
-                Some(&Path::new("/dev/").join(f)),
-                &concat_absolute(rootfs, "/dev/").join(f),
                 None::<&str>,
-                nix::mount::MsFlags::MS_BIND,
+                &concat_absolute(rootfs, "/dev/pts"),
+                Some("devpts"),
+                nix::mount::MsFlags::empty(),
                 None::<&str>,
             )
-            .expect("failed to mount device");
-        }
+            .expect("failed to mount /dev/pts");
 
-        if !cfg.isolate_network {
             nix::mount::mount(
-                Some(&std::fs::canonicalize("/etc/resolv.conf").unwrap()),
-                &concat_absolute(rootfs, "/etc/resolv.conf"),
                 None::<&str>,
-                nix::mount::MsFlags::MS_BIND,
+                &concat_absolute(rootfs, "/dev/shm"),
+                Some("tmpfs"),
+                nix::mount::MsFlags::empty(),
                 None::<&str>,
             )
-            .expect("failed to mount /etc/resolv.conf");
+            .expect("failed to mount /dev/shm");
+
+            nix::mount::mount(
+                None::<&str>,
+                &concat_absolute(rootfs, "/run"),
+                Some("tmpfs"),
+                nix::mount::MsFlags::empty(),
+                None::<&str>,
+            )
+            .expect("failed to mount /run");
+
+            nix::mount::mount(
+                None::<&str>,
+                &concat_absolute(rootfs, "/tmp"),
+                Some("tmpfs"),
+                nix::mount::MsFlags::empty(),
+                None::<&str>,
+            )
+            .expect("failed to mount /tmp");
+
+            nix::mount::mount(
+                None::<&str>,
+                &concat_absolute(rootfs, "/proc"),
+                Some("proc"),
+                nix::mount::MsFlags::empty(),
+                None::<&str>,
+            )
+            .expect("failed to mount /proc");
+
+            // Mount /var/tmp as tmpfs.
+            // TODO: Technically /var/tmp is supposed to survive boots.
+            nix::mount::mount(
+                None::<&str>,
+                &concat_absolute(rootfs, "/var/tmp"),
+                Some("tmpfs"),
+                nix::mount::MsFlags::empty(),
+                None::<&str>,
+            )
+            .expect("failed to mount /var/tmp");
+
+            // Mount /sys via recursive bind + slave.
+            // This is needed such that the container can access /sys/fs/* and similar.
+            nix::mount::mount(
+                Some(Path::new("/sys")),
+                &concat_absolute(rootfs, "/sys"),
+                None::<&str>,
+                nix::mount::MsFlags::MS_BIND | nix::mount::MsFlags::MS_REC,
+                None::<&str>,
+            )
+            .expect("failed to bind mount /sys");
+
+            nix::mount::mount(
+                None::<&str>,
+                &concat_absolute(rootfs, "/sys"),
+                None::<&str>,
+                nix::mount::MsFlags::MS_SLAVE | nix::mount::MsFlags::MS_REC,
+                None::<&str>,
+            )
+            .expect("failed to make /sys slave");
         }
-
-        nix::mount::mount(
-            None::<&str>,
-            &concat_absolute(rootfs, "/dev/pts"),
-            Some("devpts"),
-            nix::mount::MsFlags::empty(),
-            None::<&str>,
-        )
-        .expect("failed to mount /dev/pts");
-
-        nix::mount::mount(
-            None::<&str>,
-            &concat_absolute(rootfs, "/dev/shm"),
-            Some("tmpfs"),
-            nix::mount::MsFlags::empty(),
-            None::<&str>,
-        )
-        .expect("failed to mount /dev/shm");
-
-        nix::mount::mount(
-            None::<&str>,
-            &concat_absolute(rootfs, "/run"),
-            Some("tmpfs"),
-            nix::mount::MsFlags::empty(),
-            None::<&str>,
-        )
-        .expect("failed to mount /run");
-
-        nix::mount::mount(
-            None::<&str>,
-            &concat_absolute(rootfs, "/tmp"),
-            Some("tmpfs"),
-            nix::mount::MsFlags::empty(),
-            None::<&str>,
-        )
-        .expect("failed to mount /tmp");
-
-        nix::mount::mount(
-            None::<&str>,
-            &concat_absolute(rootfs, "/proc"),
-            Some("proc"),
-            nix::mount::MsFlags::empty(),
-            None::<&str>,
-        )
-        .expect("failed to mount /proc");
-
-        // Mount /var/tmp as tmpfs.
-        // TODO: Technically /var/tmp is supposed to survive boots.
-        nix::mount::mount(
-            None::<&str>,
-            &concat_absolute(rootfs, "/var/tmp"),
-            Some("tmpfs"),
-            nix::mount::MsFlags::empty(),
-            None::<&str>,
-        )
-        .expect("failed to mount /var/tmp");
-
-        // Mount /sys via recursive bind + slave.
-        // This is needed such that the container can access /sys/fs/* and similar.
-        nix::mount::mount(
-            Some(Path::new("/sys")),
-            &concat_absolute(rootfs, "/sys"),
-            None::<&str>,
-            nix::mount::MsFlags::MS_BIND | nix::mount::MsFlags::MS_REC,
-            None::<&str>,
-        )
-        .expect("failed to bind mount /sys");
-
-        nix::mount::mount(
-            None::<&str>,
-            &concat_absolute(rootfs, "/sys"),
-            None::<&str>,
-            nix::mount::MsFlags::MS_SLAVE | nix::mount::MsFlags::MS_REC,
-            None::<&str>,
-        )
-        .expect("failed to make /sys slave");
     }
 
     // Perform bind mounts requested by user.
@@ -372,8 +380,10 @@ fn run_init(cfg: &Config, workspace: Option<&Path>, run_dir: Option<&Path>) -> !
     match unsafe { nix::unistd::fork() } {
         Ok(nix::unistd::ForkResult::Child) => {
             if let Some(rootfs) = rootfs {
-                nix::unistd::chroot(rootfs).expect("failed to chroot()");
-                nix::unistd::chdir("/").expect("failed to chdir() to root directory");
+                nix::unistd::chdir(rootfs).expect("failed to chdir() to rootfs");
+                if !cfg.no_chroot {
+                    nix::unistd::chroot(".").expect("failed to chroot()");
+                }
             }
 
             // setuid/setgid in the child only such that the init process can do cleanup as root.
@@ -384,13 +394,15 @@ fn run_init(cfg: &Config, workspace: Option<&Path>, run_dir: Option<&Path>) -> !
                 .expect("failed to set UID");
 
             // Reset PATH to the default value
-            if cfg.user.uid == 0 {
-                std::env::set_var(
-                    "PATH",
-                    "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-                );
-            } else {
-                std::env::set_var("PATH", "/usr/local/bin:/usr/bin:/bin");
+            if !cfg.no_chroot {
+                if cfg.user.uid == 0 {
+                    std::env::set_var(
+                        "PATH",
+                        "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+                    );
+                } else {
+                    std::env::set_var("PATH", "/usr/local/bin:/usr/bin:/bin");
+                }
             }
 
             // Apply user-specified environment variables.

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use libc::{gid_t, uid_t};
 use nix::fcntl::{flock, open, FlockArg, OFlag};
 use nix::sys::stat::Mode;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::ffi::CString;
 use std::fs::File;
 use std::mem::forget;
@@ -24,6 +25,8 @@ struct User {
 #[derive(Serialize, Deserialize)]
 struct Process {
     args: Vec<String>,
+    #[serde(default)]
+    environ: HashMap<String, String>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -241,6 +244,11 @@ fn run_init(cfg: &Config, rootfs: Option<&Path>) -> ! {
                 );
             } else {
                 std::env::set_var("PATH", "/usr/local/bin:/usr/bin:/bin");
+            }
+
+            // Apply user-specified environment variables.
+            for (key, value) in &cfg.process.environ {
+                std::env::set_var(key, value);
             }
 
             let exec_result = nix::unistd::execvp(

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -47,6 +47,25 @@ fn run_echo() {
 }
 
 #[test]
+fn auto_subuid_subgid() {
+    let config = serde_json::json!({
+        "user": { "uid": 0, "gid": 0 },
+        "process": { "args": ["/usr/bin/id"] },
+        "bindMounts": [],
+        "subUid": { "auto": true, "self": 0 },
+        "subGid": { "auto": true, "self": 0 },
+    });
+    let f = write_config(&config);
+
+    Command::cargo_bin("cbuildrt")
+        .unwrap()
+        .arg(f.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::starts_with("uid=0(root) gid=0(root)"));
+}
+
+#[test]
 fn custom_environ() {
     let uid = rustix::process::getuid().as_raw();
     let gid = rustix::process::getgid().as_raw();

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -45,3 +45,25 @@ fn run_echo() {
         .success()
         .stdout(predicate::str::contains("hello"));
 }
+
+#[test]
+fn custom_environ() {
+    let uid = rustix::process::getuid().as_raw();
+    let gid = rustix::process::getgid().as_raw();
+    let config = serde_json::json!({
+        "user": { "uid": uid, "gid": gid },
+        "process": {
+            "args": ["sh", "-c", "echo $HELLO"],
+            "environ": { "HELLO": "hello world" },
+        },
+        "bindMounts": [],
+    });
+    let f = write_config(&config);
+
+    Command::cargo_bin("cbuildrt")
+        .unwrap()
+        .arg(f.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("hello world"));
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,47 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::io::Write;
+
+fn write_config(config: &serde_json::Value) -> tempfile::NamedTempFile {
+    let mut f = tempfile::NamedTempFile::new().unwrap();
+    serde_json::to_writer(&mut f, config).unwrap();
+    f.flush().unwrap();
+    f
+}
+
+#[test]
+fn run_true() {
+    let uid = rustix::process::getuid().as_raw();
+    let gid = rustix::process::getgid().as_raw();
+    let config = serde_json::json!({
+        "user": { "uid": uid, "gid": gid },
+        "process": { "args": ["true"] },
+        "bindMounts": [],
+    });
+    let f = write_config(&config);
+
+    Command::cargo_bin("cbuildrt")
+        .unwrap()
+        .arg(f.path())
+        .assert()
+        .success();
+}
+
+#[test]
+fn run_echo() {
+    let uid = rustix::process::getuid().as_raw();
+    let gid = rustix::process::getgid().as_raw();
+    let config = serde_json::json!({
+        "user": { "uid": uid, "gid": gid },
+        "process": { "args": ["echo", "hello"] },
+        "bindMounts": [],
+    });
+    let f = write_config(&config);
+
+    Command::cargo_bin("cbuildrt")
+        .unwrap()
+        .arg(f.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("hello"));
+}


### PR DESCRIPTION
This adds a bunch of new features that will be used by xbstrap to run debootstrap inside cbuildrt:
- Custom environment variable support.
- Flags to disable `chroot()` and mounts. This is useful for the initial debootstrap call where we need to have the host debootstrap available.
- Setting uid/gid maps via `setuidmap` and `setgidmap`. We use the same logic as `unshare --map-auto` for this purpose.
- Support for overlayfs upper layers that can be packed into tar files and then re-used as lower layers. When used as a lower layer, a tar file is extracted into a subdirectory of a workspace directory that is passed to cbuildrt. We use tar files (and not directory trees) here because they allow us to preserve ownership and permissions.
- Volumes that can store data across multiple cbuildrt runs. This can be used for the apt cache. Volumes are stored in a subdirectory of the workspace as well.